### PR TITLE
fix typo in leaflet.requery.js

### DIFF
--- a/js/leaflet/leaflet.requery.js
+++ b/js/leaflet/leaflet.requery.js
@@ -24,7 +24,7 @@
   L.Control.Requery = L.Control.extend({
     options: {
       position: 'topleft',
-      text: 'Seach area'
+      text: 'Search area'
     },
     onAdd: function(map) {
       var container = L.DomUtil.create('div', 'leaflet-control-requery leaflet-bar');


### PR DESCRIPTION
Was looking at the demo, assumed "Seach area" should really be "Search area".
